### PR TITLE
Fix: fix warnings coming due to FixedLocator in a matplotlib.ticker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-seaborn==0.12.2
-pandas==2.0.0
-matplotlib==3.7.1
-matplotlib-inline==0.1.6
-scipy==1.10.1
-numpy==1.22.0
+seaborn
+pandas
+matplotlib
+matplotlib-inline
+scipy
+numpy

--- a/vivainsights/create_bar.py
+++ b/vivainsights/create_bar.py
@@ -16,7 +16,6 @@ import matplotlib.ticker as mtick
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FixedLocator
 import matplotlib
-import warnings
 matplotlib.use("QtAgg")
     
 def create_bar_calc(

--- a/vivainsights/create_bar.py
+++ b/vivainsights/create_bar.py
@@ -14,6 +14,7 @@ from vivainsights.extract_date_range import extract_date_range
 from vivainsights.us_to_space import us_to_space
 import matplotlib.ticker as mtick
 import matplotlib.pyplot as plt
+from matplotlib.ticker import FixedLocator
 import matplotlib
 import warnings
 matplotlib.use("QtAgg")
@@ -46,97 +47,90 @@ def create_bar_viz(
     plot_title = None,
     plot_subtitle = None):
     """Visualise the mean of a selected metric, grouped by a selected HR variable."""
-    
-    # suppress warnings
-    warnings.filterwarnings("ignore")    
-    
-    # summarised output
     sum_df = create_bar_calc(data, metric, hrvar, mingroup)
-    caption_text = extract_date_range(data, return_type = 'text')
+    caption_text = extract_date_range(data, return_type='text')
     plot_order = sum_df[hrvar].to_numpy()
-    
-    # Title and subtitle text 
+
+    # Title and subtitle text
     if plot_title is None:
         title_text = us_to_space(metric)
-    else: 
-        title_text = plot_title    
-    
+    else:
+        title_text = plot_title
+
     if plot_subtitle is None:
-        subtitle_text = f'Weekly average by {hrvar}' #TODO: make this dynamic by date interval 
+        subtitle_text = f'Weekly average by {hrvar}'  # TODO: make this dynamic by date interval
     else:
         subtitle_text = plot_subtitle
-    
+
     # fig = plt.figure()
     fig, ax = plt.subplots(figsize=(4, 6))
-    
-    # Create grid 
+
+    # Create grid
     # Zorder tells it which layer to put it on. We are setting this to 1 and our data to 2 so the grid is behind the data.
     ax.grid(which="major", axis='x', color='#758D99', alpha=0.6, zorder=1)
-    
-    # Remove splines. Can be done one at a time or can slice with a list.
-    ax.spines[['top','right','bottom']].set_visible(False)
-    
+
+    # Remove splines. Can be done 1 at a time or can slice with a list.
+    ax.spines[['top', 'right', 'bottom']].set_visible(False)
+
     # Make left spine slightly thicker
     ax.spines['left'].set_linewidth(1.1)
-    
+
     ax.barh(sum_df[hrvar], sum_df['metric'], color='#1d627e', zorder=2)
-    
+
     if percent == True:
         # Set the x-axis format to percentage
         ax.xaxis.set_major_formatter(mtick.PercentFormatter(xmax=1.0))
-    
+
     # Shrink y-lim to make plot a bit tighter
     # Using length of summary table to make it dynamic
-    ax.set_ylim(-0.5, len(sum_df)-0.5)
-    
-    # Reformat x-axis tick labels
-    ax.xaxis.set_tick_params(labeltop=True,      # Put x-axis labels on top
-                            labelbottom=False,  # Set no x-axis labels on bottom
-                            bottom=False,       # Set no ticks on bottom
-                            labelsize=9,       # Set tick label size
-                            pad=-1)             # Lower tick labels a bit
+    ax.set_ylim(-0.5, len(sum_df) - 0.5)
 
-    ax.yaxis.set_tick_params(pad=10,      # Pad tick labels so they don't go over y-axis
-                            labelsize=9,  # Set label size
-                            bottom=False)  # Set no ticks on bottom/left
-    
+    # Reformat x-axis tick labels
+    ax.xaxis.set_tick_params(labeltop=True,  # Put x-axis labels on top
+                             labelbottom=False,  # Set no x-axis labels on bottom
+                             bottom=False,  # Set no ticks on bottom
+                             labelsize=9,  # Set tick label size
+                             pad=-1)  # Lower tick labels a bit
+
+    ax.yaxis.set_tick_params(pad=10,  # Pad tick labels so they don't go over y-axis
+                             labelsize=9,  # Set label size
+                             bottom=False)  # Set no ticks on bottom/left
+
     # Reformat y-axis tick labels
-    ax.set_yticklabels(
-        sum_df[hrvar],   # Set labels again
-        ha = 'right'     # Set horizontal alignment to right
-        )               
- 
+    ax.set_yticks(range(len(sum_df)))
+    ax.set_yticklabels(sum_df[hrvar], ha='right')
+
     # Add in line and tag
-    ax.plot([-.35, .87],                 # Set width of line
-            [1.02, 1.02],                # Set height of line
-            transform=fig.transFigure,   # Set location relative to plot
-            clip_on=False, 
-            color='#fe7f4f', 
+    ax.plot([-.35, .87],  # Set width of line
+            [1.02, 1.02],  # Set height of line
+            transform=fig.transFigure,  # Set location relative to plot
+            clip_on=False,
+            color='#fe7f4f',
             linewidth=.6)
-    
-    ax.add_patch(plt.Rectangle((-.35,1.02),             # Set location of rectangle by lower left corder
-                            0.12,                       # Width of rectangle
-                            -0.02,                      # Height of rectangle. Negative so it goes down.
-                            facecolor='#fe7f4f', 
-                            transform=fig.transFigure, 
-                            clip_on=False, 
-                            linewidth = 0))
-    
+
+    ax.add_patch(plt.Rectangle((-.35, 1.02),  # Set location of rectangle by lower left corder
+                               0.12,  # Width of rectangle
+                               -0.02,  # Height of rectangle. Negative so it goes down.
+                               facecolor='#fe7f4f',
+                               transform=fig.transFigure,
+                               clip_on=False,
+                               linewidth=0))
+
     # Add in title, subtitle, and caption
-    ax.text(x=-.35, y=.96, s= title_text, transform=fig.transFigure, ha='left', fontsize=13, weight='bold', alpha=.8)
-    ax.text(x=-.35, y=.925, s= subtitle_text, transform=fig.transFigure, ha='left', fontsize=11, alpha=.8)    
+    ax.text(x=-.35, y=.96, s=title_text, transform=fig.transFigure, ha='left', fontsize=13, weight='bold', alpha=.8)
+    ax.text(x=-.35, y=.925, s=subtitle_text, transform=fig.transFigure, ha='left', fontsize=11, alpha=.8)
     ax.text(x=-.35, y=.08, s=caption_text, transform=fig.transFigure, ha='left', fontsize=9, alpha=.7)
-  
+
     if percent == True:
-        ax.bar_label(ax.containers[0], labels=[f"{100*value:.0f}%" for value in sum_df['metric']], label_type="edge", padding = 3)
+        ax.bar_label(ax.containers[0], labels=[f"{100 * value:.0f}%" for value in sum_df['metric']], label_type="edge",
+                     padding=3)
     else:
-        ax.bar_label(ax.containers[0], fmt = '%.0f', label_type='edge', padding = 3) # annotate
-        
-    ax.margins(y=0.3) # pad the spacing between the number and the edge of the figure 
-     
+        ax.bar_label(ax.containers[0], fmt='%.0f', label_type='edge', padding=3)  # annotate
+
+    ax.margins(y=0.3)  # pad the spacing between the number and the edge of the figure
+
     # return the plot object
     return fig    
-    
 
 def create_bar(
     data: pd.DataFrame,

--- a/vivainsights/create_boxplot.py
+++ b/vivainsights/create_boxplot.py
@@ -134,7 +134,7 @@ def create_boxplot_viz(data: pd.DataFrame, metric, hrvar, mingroup):
         # plt.show()
         # return the plot object
         return fig    
-      
+    
         """ ggplot implementation - legacy
         plot_object = (
         ggplot(plot_data, aes(x="group", y=metric)) +

--- a/vivainsights/create_line.py
+++ b/vivainsights/create_line.py
@@ -63,32 +63,14 @@ def create_line_viz(data: pd.DataFrame, metric: str, hrvar: str, mingroup = 5):
     ax.set_xlabel('') # Remove x-axis label
 
     # Reformat y-axis tick labels
-    ax.set_yticklabels(np.arange(0,25,5),            # Set labels again
-                    ha = 'right',                 # Set horizontal alignment to right
-                    verticalalignment='bottom')   # Set vertical alignment to make labels on top of gridline      
+    ax.yaxis.set_major_locator(plt.FixedLocator(np.arange(0, 25, 5)))
+    ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{x:.0f}'))
 
     ax.yaxis.set_tick_params(pad=-2,             # Pad tick labels so they don't go over y-axis
                             labeltop=True,      # Put x-axis labels on top
                             labelbottom=False,  # Set no x-axis labels on bottom
                             bottom=False,       # Set no ticks on bottom
-                            labelsize=11)       # Set tick label size
-
-    # Add in line and tag
-    ax.plot([0.12, .9],                  # Set width of line
-            [.98, .98],                  # Set height of line
-            transform=fig.transFigure,   # Set location relative to plot
-            clip_on=False, 
-            color=col_highlight, 
-            linewidth=.6)
-
-    ax.add_patch(plt.Rectangle((0.12,.98),                 # Set location of rectangle by lower left corder
-                            0.04,                       # Width of rectangle
-                            -0.02,                      # Height of rectangle. Negative so it goes down.
-                            facecolor=col_highlight,    # Set color of rectangle
-                            transform=fig.transFigure, 
-                            clip_on=False, 
-                            linewidth = 0))
-
+                            labelsize=11)
     # Set title
     ax.text(x=0.12, y=.91, s= clean_nm, transform=fig.transFigure, ha='left', fontsize=13, weight='bold', alpha=.8)
 

--- a/vivainsights/create_rank.py
+++ b/vivainsights/create_rank.py
@@ -66,82 +66,47 @@ def create_rank_viz(data: pd.DataFrame,
     # Plot data
     # Plot horizontal lines first
     ax.hlines(
-        y=result_pivot['hrvar'],
+        y=range(len(result_pivot)),
         xmin=result_pivot['metric_min'],
         xmax=result_pivot['metric_max'],
         color='#758D99',
         zorder=2, linewidth=2, label='_nolegend_', alpha=.8
-        )
+    )
     
     # Plot bubbles next
-    ax.scatter(result_pivot['metric_min'], result_pivot['hrvar'], label='1960', s=60, color='#DB444B', zorder=3)
-    ax.scatter(result_pivot['metric_max'], result_pivot['hrvar'], label='2020', s=60, color= col_main, zorder=3)
+    ax.scatter(result_pivot['metric_min'], range(len(result_pivot)), label='1960', s=60, color='#DB444B', zorder=3)
+    ax.scatter(result_pivot['metric_max'], range(len(result_pivot)), label='2020', s=60, color=col_main, zorder=3)
     
     # Set xlim
     ax.set_xlim(0, 1.1*result_pivot['metric_max'].max())
-       
-    # Reformat x-axis tick labels
-    ax.xaxis.set_tick_params(labeltop=True,      # Put x-axis labels on top
-                            labelbottom=False,  # Set no x-axis labels on bottom
-                            bottom=False,       # Set no ticks on bottom
-                            labelsize=9,       # Set tick label size
-                            pad=-1)             # Lower tick labels a bit
     
-    ax.yaxis.set_tick_params(pad = 10, labelsize = 9, bottom = False) # no ticks on bottom
-    ax.set_yticklabels(result_pivot['hrvar'], ha = 'right', fontsize=9) # Set y-axis tick labels, align right
+    # Reformat x-axis tick labels
+    ax.xaxis.set_tick_params(labeltop=True, labelbottom=False, bottom=False, labelsize=9, pad=-1)
+    ax.yaxis.set_tick_params(pad=10, labelsize=9, bottom=False)
+    ax.set_yticks(range(len(result_pivot)))
+    ax.set_yticklabels(result_pivot['hrvar'], ha='right', fontsize=9)
     
     ax.legend(['min', 'max'],
-              loc = (-.29, 1.09),
-              ncol = 2,
-              frameon = False,
-              handletextpad = -.1,
-              handleheight = 1)
+              loc=(-.29, 1.09),
+              ncol=2,
+              frameon=False,
+              handletextpad=-.1,
+              handleheight=1)
     
     # Add in line and tag
-    ax.plot(
-        [-0.08, .9], # Set width of line
-        [1.17, 1.17], # Set height of line
-        transform = fig.transFigure, # Set location relative to plot
-        clip_on = False,
-        color = col_highlight,
-        linewidth = .6
-    )
+    ax.plot([-0.08, .9], [1.17, 1.17], transform=fig.transFigure, clip_on=False, color=col_highlight, linewidth=.6)
     
-    ax.add_patch(
-        plt.Rectangle(
-            (-0.08, 1.17),
-            0.05,
-            -0.025,
-            facecolor = col_highlight,
-            transform = fig.transFigure,
-            clip_on = False,
-            linewidth = 0
-            )
-    )
+    ax.add_patch(plt.Rectangle((-0.08, 1.17),
+                               0.05, -0.025, facecolor=col_highlight, transform=fig.transFigure, clip_on=False, linewidth=0))
     
     # Set title
-    ax.text(
-        x = -0.08, y = 1.09,
-        s = us_to_space(metric),
-        transform = fig.transFigure,
-        ha = 'left',
-        fontsize = 13,
-        weight = 'bold',
-        alpha = .8
-    )
+    ax.text(x=-0.08, y=1.09, s=us_to_space(metric), transform=fig.transFigure, ha='left', fontsize=13, weight='bold', alpha=.8)
     
     # Set subtitle
-    ax.text(
-        x = -0.08, y = 1.04,
-        s = 'By organizational attributes',
-        transform = fig.transFigure,
-        ha = 'left',
-        fontsize = 11,        
-        alpha = .8
-    )
+    ax.text(x=-0.08, y=1.04, s='By organizational attributes', transform=fig.transFigure, ha='left', fontsize=11, alpha=.8)
     
     # Set caption
-    ax.text(x = -0.08, y = 0.04, s = cap_str, transform = fig.transFigure, ha = 'left', fontsize = 9, alpha = .7)
+    ax.text(x=-0.08, y=0.04, s=cap_str, transform=fig.transFigure, ha='left', fontsize=9, alpha=.7)
     
     # return the plot object
     return fig

--- a/vivainsights/hrvar_count.py
+++ b/vivainsights/hrvar_count.py
@@ -57,6 +57,7 @@ def hrvar_count_viz(data: pd.DataFrame, hrvar: str):
         )  
     
     # Reformat y-axis tick labels
+    ax.set_yticks(range(len(sum_df)))
     ax.set_yticklabels(
         sum_df[hrvar],   # Set labels again
         ha = 'right'      # Set horizontal alignment to right


### PR DESCRIPTION
# Summary

This pull request fixes warnings due to FixedLocator in a matplotlib.ticker.

Previous runs of certain functions (plotting a matplotlib object) trigger the following warning: 
```
serWarning: FixedFormatter should only be used together with FixedLocator
```

# Changes
Changes have been applied to the following functions:
- `create_bar`
- `create_line`
- `create_rank`
- `create_boxplot`
- `hrvar_count`