### PR TITLE
Feature request: keymetrics_scan() equivalent in Python library

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,13 +6,13 @@ The changes made in this PR are:
 1. Change 1
 1. Change 2
 
-
 # Checks
 - [ ] All checks pass (run `python -m unittest discover -s tests -f` or `python run_tests_and_cleanup.py` locally)
 - [ ] Versions are updated in `pyproject.toml`, `setup.py`, and `docs/conf.py` (if applicable)
 - [ ] `NEWS.md` has been updated
 - [ ] If a new module has been added, a corresponding test has been created
 - [ ] If a new module has been created, `vivainsights/__init__.py` is updated accordingly
+- [ ] Everything under `dist` has been cleared prior to running `python setup.py sdist bdist_wheel`
 
 # Notes
 This fixes #<issue_number>

--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -1,3 +1,7 @@
+# Version 0.3.4
+
+Added `keymetrics_scan()` for visualizing multiple metrics across an organizational attribute.
+
 # Version 0.3.3
 
 Added function for calculating Chatterjee coefficient.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.abspath('..'))
 project = 'vivainsights'
 copyright = '2024, Microsoft Corporation'
 author = 'Martin Chan'
-release = '0.3.3'
+release = '0.3.4'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vivainsights"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
   { name="Martin Chan", email="martinchan@microsoft.com" },
   { name="Aadarsh Indurkhya", email="aindurkhya@microsoft.com" },

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt', encoding='utf-8') as f:
     requirements = f.read().splitlines()
 
 setup(name='vivainsights',
-      version='0.3.3',
+      version='0.3.4',
       url='https://github.com/microsoft/vivainsights',
       license= 'MIT',
       author='Martin Chan',

--- a/tests/test_keymetrics_scan.py
+++ b/tests/test_keymetrics_scan.py
@@ -1,0 +1,22 @@
+import unittest
+import pandas as pd
+import matplotlib.pyplot as plt
+from vivainsights.keymetrics_scan import keymetrics_scan
+from vivainsights.pq_data import load_pq_data
+
+class TestKeyMetricsScan(unittest.TestCase):
+    def setUp(self):
+        # Load sample data for testing
+        self.pq_data = load_pq_data()
+
+    def test_keymetrics_scan_plot(self):
+        result = keymetrics_scan(data=self.pq_data, hrvar='Organization', return_type='plot')
+        self.assertIsInstance(result, plt.Figure)
+        plt.close('all')  # Close the plot window after the test
+
+    def test_keymetrics_scan_table(self):
+        result = keymetrics_scan(data=self.pq_data, hrvar='Organization', return_type='table')
+        self.assertIsInstance(result, pd.DataFrame)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vivainsights/__init__.py
+++ b/vivainsights/__init__.py
@@ -33,3 +33,4 @@ from .create_IV import *
 from .create_bar_asis import *
 from .create_lorenz import *
 from .xicor import *
+from .keymetrics_scan import *

--- a/vivainsights/export.py
+++ b/vivainsights/export.py
@@ -14,6 +14,7 @@ from datetime import datetime
 def export(x,
            file_format='clipboard',
            path='insights export',
+           dpi=300,
            timestamp=True):
            
         """
@@ -34,6 +35,8 @@ def export(x,
             Character string specifying the method of export.
         path : str or optional 
             If exporting a file, enter the path and the desired file name. Defaults to "insights export". 
+        dpi : int or optional
+            Integer specifying the dots per inch for the image. Defaults to 300.
         timestamp : bool or optional 
             Logical vector specifying whether to include a timestamp in the file name. Defaults to True.
         
@@ -48,6 +51,11 @@ def export(x,
         - `"jpeg"`: JPEG file containing '' object is saved to specified path.
         - `"pdf"`: PDF file containing '' object is saved to specified path.
 
+        Example
+        -------
+        >>> import vivainsights as vi
+        >>> km_plot = vi.keymetrics_scan(data = vi.load_pq_data(), hrvar='Organization', return_type = "plot")
+        >>> vi.export(km_plot, file_format = 'png', path = 'keymetrics_scan', timestamp = False)
         """
     
         # Create timestamped path (if applicable)
@@ -70,7 +78,7 @@ def export(x,
             print(f"Exporting to {newpath}...")
             x.savefig( # matplotlib.savefig
                 newpath,
-                dpi = 300, # Set dots per inch
+                dpi = dpi, # Set dots per inch
                 bbox_inches="tight", # Remove extra whitespace around plot
                 facecolor='white' # Set background color to white   
                 ) 

--- a/vivainsights/keymetrics_scan.py
+++ b/vivainsights/keymetrics_scan.py
@@ -11,6 +11,7 @@ import pandas as pd
 import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
+from vivainsights.extract_date_range import extract_date_range
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.colors import Normalize
 
@@ -230,10 +231,13 @@ def keymetrics_scan(data,
 
     # Prepare the heatmap with row-wise normalization
     if return_type == "plot":
-        plt.figure(figsize=(12, 8))
+        plt.figure(figsize=(7, 4))
         variables = summary_long['variable'].unique()
         num_vars = len(variables)
         hrvar_categories = summary_long[hrvar].unique()
+        
+        # Clean labels for plotting
+        cap_str = extract_date_range(data, return_type = 'text')
 
         # Use dynamic scaling factor for figure height
         fig, axes = plt.subplots(num_vars, 1, figsize=(10, plot_row_scaling_factor * num_vars), sharex=True)
@@ -276,9 +280,13 @@ def keymetrics_scan(data,
 
         plt.suptitle(f"Key Metrics - Weekly Average by {hrvar}",
                      fontsize=16, x=0.5, y=1.02, ha='center')
+        
+        # Set source text
+        ax.text(x=0.12, y=-0.08, s=cap_str, transform=fig.transFigure, ha='left', fontsize=9, alpha=.7)
 
         plt.tight_layout(rect=[0, 0, 1, 0.95])
-        plt.show()
+        # return the plot object
+        return fig
 
     elif return_type == "table":
         return summary_table

--- a/vivainsights/keymetrics_scan.py
+++ b/vivainsights/keymetrics_scan.py
@@ -11,20 +11,23 @@ import pandas as pd
 import numpy as np
 import seaborn as sns
 import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
 
 def keymetrics_scan(data,
                     hrvar="Organization",
                     mingroup=5,
                     metrics=[
-            "Workweek_span", "Collaboration_hours", "After_hours_collaboration_hours", "Meetings",
-            "Meeting_hours", "After_hours_meeting_hours", "Low_quality_meeting_hours",
-            "Meeting_hours_with_manager_1_on_1", "Meeting_hours_with_manager", "Emails_sent",
-            "Email_hours", "After_hours_email_hours", "Generated_workload_email_hours",
-            "Total_focus_hours", "Internal_network_size", "Networking_outside_organization",
-            "External_network_size", "Networking_outside_company"
+                        "Workweek_span", "Collaboration_hours", "After_hours_collaboration_hours", "Meetings",
+                        "Meeting_hours", "After_hours_meeting_hours", "Low_quality_meeting_hours",
+                        "Meeting_hours_with_manager_1_on_1", "Meeting_hours_with_manager", "Emails_sent",
+                        "Email_hours", "After_hours_email_hours", "Generated_workload_email_hours",
+                        "Total_focus_hours", "Internal_network_size", "Networking_outside_organization",
+                        "External_network_size", "Networking_outside_company"
                     ],
                     return_type="plot",
-                    color_palette="Spectral",
+                    low_color="#4169E1",
+                    mid_color="#F1CC9E",
+                    high_color="#D8182A",
                     textsize=10):    
     
     """
@@ -83,45 +86,75 @@ def keymetrics_scan(data,
         Specifies the type of output to return. Valid values are:
         - `"plot"` (default): Generate a heatmap visualization.
         - `"table"`: Return a summary table as a pandas DataFrame.
-    color_palette : str, optional
-        - `"coolwarm"`
-        - `"RdBu"`
-        - `"Spectral"`
-        - `"PiYG"`
-        - `"PRGn"`
-        - `"BrBG"`
-        - `"RdYlBu"`
-        - `"RdYlGn"`
-        - `"Blues"`
-        - `"Reds"`
-        - `"Greens"`
-        - `"Oranges"`
-        - `"Purples"`
-        - `"Greys"`
-        - `"YlGn"`
-        - `"YlGnBu"`
-        - `"PuBu"`
-        - `"BuPu"`
-        - `"PuRd"`
-        - `"RdPu"`
-        - `"viridis"`
-        - `"plasma"`
-        - `"cividis"`
-        - `"magma"`
-        - `"inferno"`
-        - `"tab10"`
-        - `"tab20"`
-        - `"Set1"`
-        - `"Set2"`
-        - `"Set3"`
-        - `"Pastel1"`
-        - `"Pastel2"`
-        - `"Accent"`
-        - `"Dark2"`
-        - `"twilight"`
-        - `"twilight_shifted"`
-        - `"hsv"`
-        Specifies the color palette for the heatmap. Defaults to `"Spectral"`.
+    mid_color : str, optional
+    high_color: str, optional
+    low_color : str, optional
+        Color codes for low, mid, and high values in the heatmap. Defaults to:
+        - `low_color="#4169E1"` (blue)
+        - `mid_color="#F1CC9E"` (beige)
+        - `high_color="#D8182A"` (red)
+        Color codes for low, mid, and high values in the heatmap. Can be set to:
+        - `Black: "#000000"`
+        - `White: "#FFFFFF"`
+        - `Red: "#FF0000"`
+        - `Lime: "#00FF00"`
+        - `Blue: "#0000FF"`
+        - `Yellow: "#FFFF00"`
+        - `Cyan/Aqua: "#00FFFF"`
+        - `Magenta/Fuchsia: "#FF00FF"`
+        - `Silver: "#C0C0C0"`
+        - `Gray: "#808080"`
+        - `Maroon: "#800000"`
+        - `Olive: "#808000"`
+        - `Green: "#008000"`
+        - `Purple: "#800080"`
+        - `Teal: "#008080"`
+        - `Navy: "#000080"`
+        - `Light Gray: "#D3D3D3"`
+        - `Dark Gray: "#A9A9A9"`
+        - `Dim Gray: "#696969"`
+        - `Slate Gray: "#708090"`
+        - `Light Slate Gray: "#778899"`
+        - `Crimson: "#DC143C"`
+        - `Coral: "#FF7F50"`
+        - `Tomato: "#FF6347"`
+        - `Orange: "#FFA500"`
+        - `Gold: "#FFD700"`
+        - `Dark Orange: "#FF8C00"`
+        - `Light Salmon: "#FFA07A"`
+        - `Dodger Blue: "#1E90FF"`
+        - `Sky Blue: "#87CEEB"`
+        - `Steel Blue: "#4682B4"`
+        - `Light Blue: "#ADD8E6"`
+        - `Dark Blue: "#00008B"`
+        - `Medium Blue: "#0000CD"`
+        - `Royal Blue: "#4169E1"`
+        - `Sienna: "#A0522D"`
+        - `Saddle Brown: "#8B4513"`
+        - `Chocolate: "#D2691E"`
+        - `Peru: "#CD853F"`
+        - `Sandy Brown: "#F4A460"`
+        - `Tan: "#D2B48C"`
+        - `Lavender: "#E6E6FA"`
+        - `Thistle: "#D8BFD8"`
+        - `Plum: "#DDA0DD"`
+        - `Orchid: "#DA70D6"`
+        - `Peach Puff: "#FFDAB9"`
+        - `Mint Cream: "#F5FFFA"`
+        - `Forest Green: "#228B22"`
+        - `Sea Green: "#2E8B57"`
+        - `Medium Sea Green: "#3CB371"`
+        - `Spring Green: "#00FF7F"`
+        - `Pale Green: "#98FB98"`
+        - `Indian Red: "#CD5C5C"`
+        - `Rosy Brown: "#BC8F8F"`
+        - `Hot Pink: "#FF69B4"`
+        - `Deep Pink: "#FF1493"`
+        - `Light Pink: "#FFB6C1"`
+        - `Midnight Blue: "#191970"`
+        - `Cornflower Blue: "#6495ED"`
+        - `Powder Blue: "#B0E0E6"`
+        - `Light Sky Blue: "#87CEFA"`
     textsize : int, optional
         Font size for text elements in the heatmap. Defaults to `10`.
 
@@ -138,19 +171,17 @@ def keymetrics_scan(data,
 
     Examples
     --------
-    >>> import vivainsights as vi
-    >>> pq_data = vi.load_pq_data()
-    >>> vi.keymetrics_scan(data=pq_data, hrvar="Organization", mingroup=10, return_type="table")
-    # Returns a summary table grouped by "Organization" with a minimum group size of 10.
+    >>> keymetrics_scan(data=my_data, hrvar="Team", mingroup=10, return_type="table")
+    # Returns a summary table grouped by "Team" with a minimum group size of 10.
 
-    >>> vi.keymetrics_scan(data=pq_data, hrvar="Organization", metrics=["Workweek_span", "Meeting_hours"], return_type="plot")
-    # Displays a heatmap of the rescaled "Workweek_span" and "Meeting_hours" metrics grouped by "Organization".
+    >>> keymetrics_scan(data=my_data, hrvar="Department", metrics=["Workweek_span", "Meeting_hours"], return_type="plot")
+    # Displays a heatmap of the rescaled "Workweek_span" and "Meeting_hours" metrics grouped by "Department".
 
-    >>> vi.keymetrics_scan(data=pq_data, color_palette="coolwarm", textsize=12)
-    # Generates a heatmap using the "coolwarm" color palette with font size 12.
+    >>> keymetrics_scan(data=my_data, low_color="#4169E1", mid_color="#F1CC9E", high_color="#D8182A", textsize=12)
+    # Generates a heatmap using the low mid and high color palette with font size 12.
 
     """    
-    # Check if hrvar is available in the data
+    # Default group handling
     if hrvar is None:
         data['Total'] = "Total"
         hrvar = "Total"
@@ -170,30 +201,45 @@ def keymetrics_scan(data,
     employee_count = data.groupby(hrvar)['PersonId'].count().reset_index(name="Employee_Count")
     summary_table = pd.merge(grouped, employee_count, on=hrvar)
     summary_table = summary_table[summary_table["Employee_Count"] >= mingroup]
-    # Reshape for heatmap
+
     if summary_table.empty:
         raise ValueError(f"No data available after applying `mingroup` filter of {mingroup}.")
-    
+
+    # Rescale values for visualization
     summary_long = summary_table.melt(id_vars=[hrvar], var_name="Metric", value_name="Value")
-    summary_wide = summary_long.pivot(index="Metric", columns=hrvar, values="Value")
     summary_long["Value_Rescaled"] = (
-    summary_long.groupby("Metric")["Value"]
-    .transform(lambda x: (x - x.min()) / (x.max() - x.min()) if x.max() > x.min() else 0))
+        summary_long.groupby("Metric")["Value"]
+        .transform(lambda x: (x - x.min()) / (x.max() - x.min()) if x.max() > x.min() else 0))
 
     if return_type == "table":
-        return summary_wide
+        return summary_table
 
     elif return_type == "plot":
         plt.figure(figsize=(12, 8))
+
+        # Custom colormap
+        custom_cmap = LinearSegmentedColormap.from_list(
+            "custom_cmap", [low_color, mid_color, high_color]
+        )
+
         heatmap_data = summary_long[summary_long["Metric"] != "Employee_Count"]
         heatmap_pivot = heatmap_data.pivot(index="Metric", columns=hrvar, values="Value_Rescaled")
-        cmap = sns.color_palette(color_palette, as_cmap=True)
-        sns.heatmap(heatmap_pivot, fmt=".1f", cmap=cmap,annot=True, cbar=True,cbar_kws={"label": "Rescaled Value"})
-        plt.title("Key Metrics\nWeekly average by " + hrvar, fontsize=16)
+
+        sns.heatmap(
+            heatmap_pivot,
+            cmap=custom_cmap,
+            annot=True,
+            cbar=True,
+            cbar_kws={"label": "Rescaled Value"},
+            fmt=".1f"
+        )
+
+        plt.title(f"Key Metrics\nWeekly average by {hrvar}", fontsize=16)
         plt.ylabel("")
         plt.xlabel("")
-        plt.xticks(rotation=90)
+        plt.xticks(rotation=90, fontsize=textsize)
+        plt.yticks(fontsize=textsize)
         plt.show()
 
     else:
-        raise ValueError("Please enter a valid input for `return_type`.")
+        raise ValueError("Invalid value for `return_type`. Choose 'plot' or 'table'.")

--- a/vivainsights/keymetrics_scan.py
+++ b/vivainsights/keymetrics_scan.py
@@ -1,0 +1,197 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+"""
+This script generate a summary of key metrics with options to return a heatmap or a summary table.
+"""
+
+import pandas as pd
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+def keymetrics_scan(data,
+                    hrvar="Organization",
+                    mingroup=5,
+                    metrics=[
+            "Workweek_span", "Collaboration_hours", "After_hours_collaboration_hours", "Meetings",
+            "Meeting_hours", "After_hours_meeting_hours", "Low_quality_meeting_hours",
+            "Meeting_hours_with_manager_1_on_1", "Meeting_hours_with_manager", "Emails_sent",
+            "Email_hours", "After_hours_email_hours", "Generated_workload_email_hours",
+            "Total_focus_hours", "Internal_network_size", "Networking_outside_organization",
+            "External_network_size", "Networking_outside_company"
+                    ],
+                    return_type="plot",
+                    color_palette="Spectral",
+                    textsize=10):    
+    
+    """
+    Generate a summary of key metrics with options to return a heatmap or a summary table.
+
+    Parameters:
+    - data: pandas DataFrame containing the input data.
+    - hrvar: Column name to group by, defaults to "Organization".
+    - mingroup: Minimum number of employees required to include a group.
+    - metrics: List of metric column names to calculate averages for.
+    - return_type: "plot" for heatmap or "table" for summary table.
+    - low, mid, high: Color codes for low, mid, and high values in the heatmap.
+    - textsize: Font size for the text in the plot.
+
+    Returns:
+    - A seaborn heatmap (plot) or a summary table (DataFrame).
+    """
+    """
+    Name
+    ----
+    keymetrics_scan
+
+    Description
+    ------------
+    This function generates a summary of key metrics from a given dataset with options to return a heatmap visualization or a summary table.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        The input data containing the metrics to analyze.
+    hrvar : str, optional
+        The column name to group the data by. Defaults to `"Organization"`.
+    mingroup : int, optional
+        The minimum number of employees required to include a group in the analysis. Defaults to `5`.
+    metrics : list of str, optional
+        A list of metric column names to calculate averages for. Defaults to:
+        - `"Workweek_span"`
+        - `"Collaboration_hours"`
+        - `"After_hours_collaboration_hours"`
+        - `"Meetings"`
+        - `"Meeting_hours"`
+        - `"After_hours_meeting_hours"`
+        - `"Low_quality_meeting_hours"`
+        - `"Meeting_hours_with_manager_1_on_1"`
+        - `"Meeting_hours_with_manager"`
+        - `"Emails_sent"`
+        - `"Email_hours"`
+        - `"After_hours_email_hours"`
+        - `"Generated_workload_email_hours"`
+        - `"Total_focus_hours"`
+        - `"Internal_network_size"`
+        - `"Networking_outside_organization"`
+        - `"External_network_size"`
+        - `"Networking_outside_company"`
+    return_type : str, optional
+        Specifies the type of output to return. Valid values are:
+        - `"plot"` (default): Generate a heatmap visualization.
+        - `"table"`: Return a summary table as a pandas DataFrame.
+    color_palette : str, optional
+        - `"coolwarm"`
+        - `"RdBu"`
+        - `"Spectral"`
+        - `"PiYG"`
+        - `"PRGn"`
+        - `"BrBG"`
+        - `"RdYlBu"`
+        - `"RdYlGn"`
+        - `"Blues"`
+        - `"Reds"`
+        - `"Greens"`
+        - `"Oranges"`
+        - `"Purples"`
+        - `"Greys"`
+        - `"YlGn"`
+        - `"YlGnBu"`
+        - `"PuBu"`
+        - `"BuPu"`
+        - `"PuRd"`
+        - `"RdPu"`
+        - `"viridis"`
+        - `"plasma"`
+        - `"cividis"`
+        - `"magma"`
+        - `"inferno"`
+        - `"tab10"`
+        - `"tab20"`
+        - `"Set1"`
+        - `"Set2"`
+        - `"Set3"`
+        - `"Pastel1"`
+        - `"Pastel2"`
+        - `"Accent"`
+        - `"Dark2"`
+        - `"twilight"`
+        - `"twilight_shifted"`
+        - `"hsv"`
+        Specifies the color palette for the heatmap. Defaults to `"Spectral"`.
+    textsize : int, optional
+        Font size for text elements in the heatmap. Defaults to `10`.
+
+    Returns
+    -------
+    - If `return_type="plot"`: Displays a heatmap visualization of the rescaled key metrics grouped by the specified HR attribute.
+    - If `return_type="table"`: Returns a pandas DataFrame containing a summary table of average metric values grouped by the specified HR attribute.
+
+    Raises
+    ------
+    ValueError
+        - If none of the specified metrics are present in the dataset.
+        - If no data is available after applying the `mingroup` filter.
+
+    Examples
+    --------
+    >>> keymetrics_scan(data=my_data, hrvar="Team", mingroup=10, return_type="table")
+    # Returns a summary table grouped by "Team" with a minimum group size of 10.
+
+    >>> keymetrics_scan(data=my_data, hrvar="Department", metrics=["Workweek_span", "Meeting_hours"], return_type="plot")
+    # Displays a heatmap of the rescaled "Workweek_span" and "Meeting_hours" metrics grouped by "Department".
+
+    >>> keymetrics_scan(data=my_data, color_palette="coolwarm", textsize=12)
+    # Generates a heatmap using the "coolwarm" color palette with font size 12.
+
+    """    
+    # Check if hrvar is available in the data
+    if hrvar is None:
+        data['Total'] = "Total"
+        hrvar = "Total"
+
+    # Filter metrics available in the data
+    metrics = [metric for metric in metrics if metric in data.columns]
+    if not metrics:
+        raise ValueError("None of the specified metrics are available in the data.")
+
+    # Group and summarize the data
+    grouped = (data.groupby([hrvar, "PersonId"])[metrics]
+               .mean()
+               .groupby(hrvar)
+               .mean()
+               .reset_index())
+
+    employee_count = data.groupby(hrvar)['PersonId'].count().reset_index(name="Employee_Count")
+    summary_table = pd.merge(grouped, employee_count, on=hrvar)
+    summary_table = summary_table[summary_table["Employee_Count"] >= mingroup]
+    # Reshape for heatmap
+    if summary_table.empty:
+        raise ValueError(f"No data available after applying `mingroup` filter of {mingroup}.")
+    
+    summary_long = summary_table.melt(id_vars=[hrvar], var_name="Metric", value_name="Value")
+    summary_wide = summary_long.pivot(index="Metric", columns=hrvar, values="Value")
+    summary_long["Value_Rescaled"] = (
+    summary_long.groupby("Metric")["Value"]
+    .transform(lambda x: (x - x.min()) / (x.max() - x.min()) if x.max() > x.min() else 0))
+
+    if return_type == "table":
+        return summary_wide
+
+    elif return_type == "plot":
+        plt.figure(figsize=(12, 8))
+        heatmap_data = summary_long[summary_long["Metric"] != "Employee_Count"]
+        heatmap_pivot = heatmap_data.pivot(index="Metric", columns=hrvar, values="Value_Rescaled")
+        cmap = sns.color_palette(color_palette, as_cmap=True)
+        sns.heatmap(heatmap_pivot, fmt=".1f", cmap=cmap,annot=True, cbar=True,cbar_kws={"label": "Rescaled Value"})
+        plt.title("Key Metrics\nWeekly average by " + hrvar, fontsize=16)
+        plt.ylabel("")
+        plt.xlabel("")
+        plt.xticks(rotation=90)
+        plt.show()
+
+    else:
+        raise ValueError("Please enter a valid input for `return_type`.")

--- a/vivainsights/keymetrics_scan.py
+++ b/vivainsights/keymetrics_scan.py
@@ -138,13 +138,15 @@ def keymetrics_scan(data,
 
     Examples
     --------
-    >>> keymetrics_scan(data=my_data, hrvar="Team", mingroup=10, return_type="table")
-    # Returns a summary table grouped by "Team" with a minimum group size of 10.
+    >>> import vivainsights as vi
+    >>> pq_data = vi.load_pq_data()
+    >>> vi.keymetrics_scan(data=pq_data, hrvar="Organization", mingroup=10, return_type="table")
+    # Returns a summary table grouped by "Organization" with a minimum group size of 10.
 
-    >>> keymetrics_scan(data=my_data, hrvar="Department", metrics=["Workweek_span", "Meeting_hours"], return_type="plot")
-    # Displays a heatmap of the rescaled "Workweek_span" and "Meeting_hours" metrics grouped by "Department".
+    >>> vi.keymetrics_scan(data=pq_data, hrvar="Organization", metrics=["Workweek_span", "Meeting_hours"], return_type="plot")
+    # Displays a heatmap of the rescaled "Workweek_span" and "Meeting_hours" metrics grouped by "Organization".
 
-    >>> keymetrics_scan(data=my_data, color_palette="coolwarm", textsize=12)
+    >>> vi.keymetrics_scan(data=pq_data, color_palette="coolwarm", textsize=12)
     # Generates a heatmap using the "coolwarm" color palette with font size 12.
 
     """    

--- a/vivainsights/keymetrics_scan.py
+++ b/vivainsights/keymetrics_scan.py
@@ -36,10 +36,11 @@ def keymetrics_scan(data,
                              "External_network_size",
                              "Networking_outside_company"],
                     return_type="plot",
-                    low="#0770A1",
-                    high="#D8182A",
+                    low_color="#4169E1",
+                    mid_color="#F1CC9E",
+                    high_color="#D8182A",
                     textsize=10,
-                    row_scaling_factor=0.8):    
+                    plot_row_scaling_factor=0.8):    
     
     """
     Generate a summary of key metrics with options to return a heatmap or a summary table.
@@ -235,9 +236,11 @@ def keymetrics_scan(data,
         hrvar_categories = summary_long[hrvar].unique()
 
         # Use dynamic scaling factor for figure height
-        fig, axes = plt.subplots(num_vars, 1, figsize=(10, row_scaling_factor * num_vars), sharex=True)
+        fig, axes = plt.subplots(num_vars, 1, figsize=(10, plot_row_scaling_factor * num_vars), sharex=True)
 
         for i, variable in enumerate(variables):
+            custom_cmap = LinearSegmentedColormap.from_list(
+            "custom_cmap", [low_color, mid_color, high_color])
             ax = axes[i] if num_vars > 1 else axes
             subset = summary_long[summary_long['variable'] == variable]
             row_min = subset['value'].min()
@@ -251,7 +254,7 @@ def keymetrics_scan(data,
             sns.heatmap(heatmap_data,
                         annot=subset['value'].values.reshape(1, -1),
                         fmt=".1f",
-                        cmap=sns.diverging_palette(250, 10, as_cmap=True),
+                        cmap=custom_cmap,
                         cbar=False,
                         linewidths=0.5,
                         vmin=0,

--- a/vivainsights/keymetrics_scan.py
+++ b/vivainsights/keymetrics_scan.py
@@ -171,13 +171,15 @@ def keymetrics_scan(data,
 
     Examples
     --------
-    >>> keymetrics_scan(data=my_data, hrvar="Team", mingroup=10, return_type="table")
+    >>> import vivainsights as vi
+    >>> pq_data = vi.load_pq_data()
+    >>> vi.keymetrics_scan(data=pq_data, hrvar="Organization", mingroup=10, return_type="table")
     # Returns a summary table grouped by "Team" with a minimum group size of 10.
 
-    >>> keymetrics_scan(data=my_data, hrvar="Department", metrics=["Workweek_span", "Meeting_hours"], return_type="plot")
+    >>> vi.keymetrics_scan(data=pq_data, hrvar="Organization", metrics=["Workweek_span", "Meeting_hours"], return_type="plot")
     # Displays a heatmap of the rescaled "Workweek_span" and "Meeting_hours" metrics grouped by "Department".
 
-    >>> keymetrics_scan(data=my_data, low_color="#4169E1", mid_color="#F1CC9E", high_color="#D8182A", textsize=12)
+    >>> vi.keymetrics_scan(data=pq_data, low_color="#4169E1", mid_color="#F1CC9E", high_color="#D8182A", textsize=12)
     # Generates a heatmap using the low mid and high color palette with font size 12.
 
     """    

--- a/vivainsights/network_p2p.py
+++ b/vivainsights/network_p2p.py
@@ -143,24 +143,26 @@ def network_p2p(data,
 
     Examples
     --------
-    >>> vi.network_p2p(data = p2p_data, return_type = "plot")
+    >>> import vivainsights as vi
+    >>> sample_data = vi.p2p_data_sim()
+    >>> vi.network_p2p(data = sample_data, return_type = "plot")
     # Return a network visual
     
-    >>> vi.network_p2p(data = p2p_data, community = "leiden", comm_args = {"resolution": 0.01}, return_type = "table")
+    >>> vi.network_p2p(data = sample_data, community = "leiden", comm_args = {"resolution": 0.01}, return_type = "table")
     # Return the vertex table with counts in communities and HR attribute
     # Resolution is set to a low value to yield fewer communities
     
-    >>> vi.network_p2p(data = p2p_data, centrality = "betweenness", return_type = "table")
+    >>> vi.network_p2p(data = sample_data, centrality = "betweenness", return_type = "table")
     # Return the vertex table with centrality calculations
     
     >>> vi.network_p2p(
-        data = p2p_data, # or whatever your query is stored
+        data = sample_data, # or whatever your query is stored
         node_scale = 50, # adjust this parameter to make nodes bigger/smaller
         return_type = "plot"
         )
     
     >>> vi.network_p2p(
-        data=p2p_data, # or whatever your query is stored
+        data = sample_data, # or whatever your query is stored
         return_type = "sankey", # another return type for visualization 
         centrality = "betweenness", # centrality can be set as per requirement
         community = "leiden" # Adjust community 
@@ -168,7 +170,7 @@ def network_p2p(data,
     # Return the sankey output based on centrality and community
     
     >>> vi.network_p2p(
-        data=p2p_data, # or whatever your query is stored
+        data = sample_data, # or whatever your query is stored
         return_type = "plot",
         font_col = "grey20", # Color change option for fonts in chart
         legend_pos = "upper left", # Adjust the legend position using this parameter


### PR DESCRIPTION
# Summary
This branch introduces the `keymetrics_scan` function, which generates a summary of key metrics from a given dataset. Users can visualize the data as a heatmap or retrieve a summary table based on specified grouping and filters. This PR also bumps the version to `0.3.4` to [PyPI](https://pypi.org/project/vivainsights/0.3.4/) and updates the documentation to include the new function. 

# Changes
The changes made in this PR are:
1. Added the `keymetrics_scan` function to generate key metric summaries using Pandas, Seaborn, and Matplotlib.
2. Implemented functionality for group-level filtering based on a minimum group size (`mingroup`).
3. Included support for multiple metrics, dynamic rescaling, and customizable visualizations.
4. Added error handling for invalid input data or empty results after filtering.
5. Integrated a flexible interface for return types (`plot` or `table`) and customizable heatmap aesthetics.
6. Added unit tests for the `keymetrics_scan` function.

# Checks
- [x] All checks pass (run `python -m unittest discover -s tests -f` or `python run_tests_and_cleanup.py` locally)
- [x] Versions are updated in `pyproject.toml`, `setup.py`, and `docs/conf.py` (if applicable)
- [x] `NEWS.md` has been updated
- [x] If a new module has been added, a corresponding test has been created
- [x] If a new module has been created, `vivainsights/__init__.py` is updated accordingly

# Example

```python
import vivainsights as vi
import matplotlib.pyplot as plt

pq_data = vi.load_pq_data()
vi.keymetrics_scan(pq_data, hrvar = 'Organization', return_type = "plot")
plt.show()
```
![image](https://github.com/user-attachments/assets/335727e7-03b5-423d-b7f4-c73a798fce45)

# Notes
This fixes #36. 
