### PR TITLE
feat: add privacy-preserving Umami analytics to Sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -82,6 +82,22 @@ html_css_files = [
     'custom.css',
 ]
 
+# Privacy-preserving analytics. data-domains restricts collection to the
+# published documentation host, so local builds do not send data.
+html_js_files = [
+    (
+        "https://ca-umami-prod.lemonglacier-6a5930b7.uksouth.azurecontainerapps.io/script.js",
+        {
+            "defer": "defer",
+            "data-website-id": "c621353a-f4f5-4f73-ad75-9317cd1a0401",
+            "data-domains": "microsoft.github.io",
+            "data-do-not-track": "true",
+            "data-exclude-search": "true",
+            "data-exclude-hash": "true",
+        },
+    ),
+]
+
 # Recognize both .rst and .md files as source files
 source_suffix = {
     '.rst': 'restructuredtext',


### PR DESCRIPTION
Adds the shared self-hosted [Umami](https://umami.is/) tracker to the Sphinx documentation site, matching the approach used in microsoft/viva-insights-sample-code#3.

## Changes

- `docs/conf.py`: adds `html_js_files` with the tracker URL and its data attributes. Sphinx passes absolute URLs through unchanged, so nothing is copied into `_static`.

## Privacy and safety

- `data-domains="microsoft.github.io"` restricts collection to the published site, so local `make html` builds do not send data.
- `data-do-not-track="true"` honours the visitor's browser preference.
- `data-exclude-search` and `data-exclude-hash` keep query strings and URL fragments out of analytics.
- Umami is cookieless and stores no personal data. The website ID is an identifier, not a credential, and is expected to appear in page source.
- The existing `html_css_files` entry is unchanged.

## Verification after merge

1. Confirm the `sphinx_wf.yml` workflow publishes successfully.
2. Load https://microsoft.github.io/vivainsights-py/ and check `script.js` returns HTTP 200 and `/api/send` succeeds.
3. Confirm the pageview appears under the `vivainsights (Python)` property in Umami realtime.